### PR TITLE
Improve asm16 instruction & error messaging

### DIFF
--- a/assembly-crash-course/run
+++ b/assembly-crash-course/run
@@ -1144,12 +1144,11 @@ class ASMLevel16(ASMBase):
         Similar to the memory levels we can use [rsp] to access the value at the memory address in rsp.
 
         Without using pop please calculate the average of 4 consecutive quad words stored on the stack.
-        Store the average on the top of the stack. Hint:
+        Push the average on the stack. Hint:
         RSP+0x?? Quad Word A
         RSP+0x?? Quad Word B
         RSP+0x?? Quad Word C
         RSP      Quad Word D
-        RSP-0x?? Average
 
         We will now set the following in preparation for your code:
         (stack) [{hex(self.RSP_INIT)}:{hex(self.init_rsp)}]
@@ -1159,7 +1158,8 @@ class ASMLevel16(ASMBase):
     def trace(self):
         self.start()
         expected = sum(self.init_mem_stack) // 4
-        yield self[self.init_rsp - 8 : self.init_rsp] == (expected).to_bytes(8, "little"), f"[{hex(self.init_rsp)}] expected to be {hex(expected)}, but was {hex(int.from_bytes(self[self.init_rsp - 8 : self.init_rsp], 'little'))} instead"
+        yield self[self.init_rsp - 8 : self.init_rsp] == (expected).to_bytes(8, "little"), f"[{hex(self.init_rsp - 8)}] expected to be {hex(expected)}, but was {hex(int.from_bytes(self[self.init_rsp - 8 : self.init_rsp], 'little'))} instead"
+        yield self.rsp == self.init_rsp - 8, f"rsp expected to be {hex(self.init_rsp - 8)}, but was {hex(self.rsp)} instead"
 
 
 class ASMLevel17(ASMBase):


### PR DESCRIPTION
- Original instructions unclear a push was expected.
- Original error messaging could result in incorrect error message regarding memory address and value.