### PR TITLE
change resource link to archive.org one

### DIFF
--- a/dojo.yml
+++ b/dojo.yml
@@ -637,7 +637,7 @@ modules:
       - Some [documentation](https://www.binarytides.com/socket-programming-c-linux-tutorial/) on networking in C.
       - Useful resource for [pipes in C](https://jameshfisher.com/2017/02/17/how-do-i-call-a-program-in-c-with-pipes/).
       - Useful resource for [FIFOs in C](https://www.geeksforgeeks.org/named-pipe-fifo-example-c-program/).
-      - A treatise on I/O redirection in Linux shells, which has applications in this assignment: [https://bencane.com/2012/04/16/unix-shell-the-art-of-io-redirection/](https://bencane.com/2012/04/16/unix-shell-the-art-of-io-redirection/)
+      - A treatise on I/O redirection in Linux shells, which has applications in this assignment: [https://web.archive.org/web/20220629044814/https://bencane.com/2012/04/16/unix-shell-the-art-of-io-redirection/](https://web.archive.org/web/20220629044814/https://bencane.com/2012/04/16/unix-shell-the-art-of-io-redirection/)
       - A guide on Linux symbolic links. [https://www.nixtutor.com/freebsd/understanding-symbolic-links/](https://www.nixtutor.com/freebsd/understanding-symbolic-links/)
       - A video tutorial on [FIFOs in C](https://www.youtube.com/watch?v=2hba3etpoJg).
       - A great [visual guide to I/O redirection in Linux](http://www.rozmichelle.com/pipes-forks-dups/).


### PR DESCRIPTION
Original link is dead, changed it to archive.org's latest snapshot. Noticed by @mikewind22 on discord.