### PR TITLE
Bypass “nc-only” check via root-owned writable dirs

### DIFF
--- a/talking-web/http-nc/_0/server
+++ b/talking-web/http-nc/_0/server
@@ -30,10 +30,10 @@ def name_of_program_for(process):
     for p in reversed(client_path.parents):
         if p.owner() != "root":
             return None
-        if str(p) in ("/home", "/tmp", "/var/tmp", "/dev/shm"):
+        if str(p) in ("/home", "/tmp", "/var/tmp", "/dev/shm", "/var/cache/sympow/datafiles", "/var/cache/sympow/datafiles/le64", "
+/var/lib/php/sessions", "/run/lock", "/run/dojo/var", "/run/screen"):
             return None
     return client_path.stem
-
 
 @app.route("/", methods=["GET"])
 def challenge():


### PR DESCRIPTION
This PR closes a bypass where the “nc-only” client check can be satisfied by running any ELF binary named nc from a root-owned but user-writable directory (e.g. /run/lock, the one I personally tried), because the current validation only checks parent directory ownership and blocks a small denylist (/home, /tmp, /var/tmp, /dev/shm).

Perhaps this is intended for students who want to try solving it another way after reading the server file? (Me because I enjoy poking around). 
If that is the case, I apologize for disturbing you Zardus :D