### PR TITLE
Correction of an incorrect spelling in SQL-Playground "Choosing Colum…

### DIFF
--- a/sql-playground/module.yml
+++ b/sql-playground/module.yml
@@ -54,7 +54,7 @@ challenges:
 - id: sql-where-one
   name: "Choosing Columns"
   description: |
-    You've probably been using `SELECT *` because of our sublimital suggestion a few challenges ago.
+    You've probably been using `SELECT *` because of our subliminal suggestion a few challenges ago.
     This challenge will force you to choose a single column.
     `SELECT` it by name and get the flag!
   auxiliary:


### PR DESCRIPTION
…ns" challenge

Nothing to note, sublimital was written... which is not a word. It should be subliminal